### PR TITLE
Improve Windows installer icon and multi-PS support

### DIFF
--- a/scripts/nsis_template.nsi
+++ b/scripts/nsis_template.nsi
@@ -20,9 +20,14 @@ RequestExecutionLevel admin
 !define APP_DIRNAME     "__APP_DIRNAME__"  ; 安装到 Plug-ins 下的目录名
 !define APP_NAME_FILE   "__APP_NAME_FILE__"
 !define OUT_FILENAME    "${APP_NAME_FILE}_${APP_VERSION}.exe"
+!define INSTALLER_ICON "__INSTALLER_ICON__"
 
 Name        "${APP_NAME}"
 OutFile     "${OUT_FILENAME}"
+!if "${INSTALLER_ICON}" != ""
+Icon "${INSTALLER_ICON}"
+UninstallIcon "${INSTALLER_ICON}"
+!endif
 BrandingText "Installer • ${APP_PUBLISHER}"
 
 VIProductVersion "${APP_VERSION_4}"
@@ -47,6 +52,9 @@ Page custom PreInstallConfirm
 Var PSPATH
 Var _found
 Var _tmp
+Var PSCount
+Var PSFoundPath
+Var PSFoundNormalized
 
 ; ---------- 小宏：尝试读取注册表字符串 ----------
 !macro TRY_READ REGROOT SUBKEY VALUENAME
@@ -81,6 +89,39 @@ Function NormalizeFromTmp
 
 done:
 FunctionEnd
+
+; 将找到的 Photoshop 目录入栈并计数
+Function StoreFoundPath
+  Pop $PSFoundPath
+  Push $0
+  Push $1
+
+  StrCpy $PSFoundNormalized $PSFoundPath
+  ${GetFullPathName} $PSFoundNormalized "$PSFoundNormalized"
+
+TrimLoop:
+  StrLen $0 $PSFoundNormalized
+  IntCmp $0 0 TrimDone
+  StrCpy $1 $PSFoundNormalized 1 -1
+  StrCmp $1 "\\" TrimDrop 0
+  StrCmp $1 "/" TrimDrop 0
+  Goto TrimDone
+
+TrimDrop:
+  StrCpy $PSFoundNormalized $PSFoundNormalized -1
+  Goto TrimLoop
+
+TrimDone:
+  StrCmp $PSFoundNormalized "" Restore
+
+  Push $PSFoundNormalized
+  IntOp $PSCount $PSCount + 1
+
+Restore:
+  Pop $1
+  Pop $0
+  StrCpy $_found ""
+FunctionEnd
 Function PreInstallConfirm
   ; 一个极简的 nsDialogs 页面，只有提示文本与“下一步”按钮
   nsDialogs::Create 1018
@@ -96,17 +137,16 @@ Function PreInstallConfirm
 FunctionEnd
 
 ; ---------- 查找 Photoshop ----------
-; 只做“自动检测”，不弹窗；手选放在 Section 里做
+; 自动检测所有 Photoshop，并允许用户补充
 Function FindPhotoshop
-  ; —— 只做自动检测，不弹窗；手选在 Section 里做 ——
   StrCpy $PSPATH ""
   StrCpy $_found  ""
   StrCpy $_tmp    ""
+  StrCpy $PSCount 0
 
   ; ===== 64-bit 视图 =====
   SetRegView 64
 
-  ; HKLM\SOFTWARE\Adobe\Photoshop\*\ApplicationPath  (默认值 "")
   StrCpy $0 0
 Find_HKLM64_Loop:
   ClearErrors
@@ -114,12 +154,13 @@ Find_HKLM64_Loop:
   IfErrors Find_HKCU64_Start
   ReadRegStr $_tmp HKLM "SOFTWARE\Adobe\Photoshop\$1\ApplicationPath" ""
   Call NormalizeFromTmp
-  StrCmp $_found "1" found_done 0
+  StrCmp $_found "1" 0 +4
+    Push $PSPATH
+    Call StoreFoundPath
   IntOp $0 $0 + 1
   Goto Find_HKLM64_Loop
 
 Find_HKCU64_Start:
-  ; HKCU\SOFTWARE\Adobe\Photoshop\*\ApplicationPath  (默认值 "")
   StrCpy $0 0
 Find_HKCU64_Loop:
   ClearErrors
@@ -127,24 +168,28 @@ Find_HKCU64_Loop:
   IfErrors Check_AppPaths64
   ReadRegStr $_tmp HKCU "SOFTWARE\Adobe\Photoshop\$1\ApplicationPath" ""
   Call NormalizeFromTmp
-  StrCmp $_found "1" found_done 0
+  StrCmp $_found "1" 0 +4
+    Push $PSPATH
+    Call StoreFoundPath
   IntOp $0 $0 + 1
   Goto Find_HKCU64_Loop
 
 Check_AppPaths64:
-  ; App Paths\Photoshop.exe（默认值可能是 EXE 全路径）
   ReadRegStr $_tmp HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Photoshop.exe" ""
   Call NormalizeFromTmp
-  StrCmp $_found "1" found_done 0
+  StrCmp $_found "1" 0 +4
+    Push $PSPATH
+    Call StoreFoundPath
 
   ReadRegStr $_tmp HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Photoshop.exe" ""
   Call NormalizeFromTmp
-  StrCmp $_found "1" found_done 0
+  StrCmp $_found "1" 0 +4
+    Push $PSPATH
+    Call StoreFoundPath
 
   ; ===== 32-bit 视图（兜底）=====
   SetRegView 32
 
-  ; HKLM\SOFTWARE\Adobe\Photoshop\*\ApplicationPath  (默认值 "")
   StrCpy $0 0
 Find_HKLM32_Loop:
   ClearErrors
@@ -152,12 +197,13 @@ Find_HKLM32_Loop:
   IfErrors Find_HKCU32_Start
   ReadRegStr $_tmp HKLM "SOFTWARE\Adobe\Photoshop\$1\ApplicationPath" ""
   Call NormalizeFromTmp
-  StrCmp $_found "1" found_done 0
+  StrCmp $_found "1" 0 +4
+    Push $PSPATH
+    Call StoreFoundPath
   IntOp $0 $0 + 1
   Goto Find_HKLM32_Loop
 
 Find_HKCU32_Start:
-  ; HKCU\SOFTWARE\Adobe\Photoshop\*\ApplicationPath  (默认值 "")
   StrCpy $0 0
 Find_HKCU32_Loop:
   ClearErrors
@@ -165,26 +211,57 @@ Find_HKCU32_Loop:
   IfErrors Check_AppPaths32
   ReadRegStr $_tmp HKCU "SOFTWARE\Adobe\Photoshop\$1\ApplicationPath" ""
   Call NormalizeFromTmp
-  StrCmp $_found "1" found_done 0
+  StrCmp $_found "1" 0 +4
+    Push $PSPATH
+    Call StoreFoundPath
   IntOp $0 $0 + 1
   Goto Find_HKCU32_Loop
 
 Check_AppPaths32:
   ReadRegStr $_tmp HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Photoshop.exe" ""
   Call NormalizeFromTmp
-  StrCmp $_found "1" found_done 0
+  StrCmp $_found "1" 0 +4
+    Push $PSPATH
+    Call StoreFoundPath
 
   ReadRegStr $_tmp HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Photoshop.exe" ""
   Call NormalizeFromTmp
-  StrCmp $_found "1" found_done 0
+  StrCmp $_found "1" 0 +4
+    Push $PSPATH
+    Call StoreFoundPath
 
-  ; 没找到就让 Section 后续的“常见目录 + 手选”接力
-  Goto done
+  ; ===== 手动选择（必要或追加）=====
+  StrCmp $PSCount 0 ManualRequired ManualOptional
 
-found_done:
-  ; 这里 $PSPATH 已是目录；若极端情况是 EXE 路径，NormalizeFromTmp 已取父目录
-  ; 不做 UI，仅返回 $PSPATH 供 Section 使用
-done:
+ManualRequired:
+  MessageBox MB_ICONEXCLAMATION|MB_OKCANCEL "未能自动找到 Photoshop 安装目录。是否手动选择？$\r$\n（请选择包含 Photoshop.exe 的目录）" IDCANCEL ManualAbort
+  Goto ManualSelect
+
+ManualOptional:
+  MessageBox MB_ICONQUESTION|MB_YESNO "已自动检测到 $PSCount 个 Photoshop 安装目录。是否额外手动添加其他目录？" IDNO FinishDetection
+
+ManualSelect:
+  nsDialogs::SelectFolderDialog "选择 Photoshop 安装目录（包含 Photoshop.exe 的那一层）" "$PROGRAMFILES\Adobe"
+  Pop $0
+  StrCmp "$0" "" ManualCancel
+  IfFileExists "$0\Photoshop.exe" 0 ManualInvalid
+  Push $0
+  Call StoreFoundPath
+  MessageBox MB_ICONQUESTION|MB_YESNO "是否继续添加其他 Photoshop 安装目录？" IDYES ManualSelect
+  Goto FinishDetection
+
+ManualInvalid:
+  MessageBox MB_ICONSTOP "选择的目录下未找到 Photoshop.exe，请重试。"
+  Goto ManualSelect
+
+ManualCancel:
+  StrCmp $PSCount 0 ManualAbort FinishDetection
+
+ManualAbort:
+  StrCpy $PSCount 0
+
+FinishDetection:
+  Push $PSCount
 FunctionEnd
 
 
@@ -196,51 +273,54 @@ Function .onInit
 FunctionEnd
 
 
+Function InstallIntoCurrent
+  Push $0
+  Push $1
+  CreateDirectory "$INSTDIR"
+  SetOutPath "$INSTDIR"
+  File /r "__PAYLOAD_GLOB__"
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+  Pop $1
+  Pop $0
+FunctionEnd
+
+
 ; ---------- 安装 ----------
 Section "Install"
   SetShellVarContext all
 
-  ; 进入安装阶段再检测（此时弹窗安全）
   Call FindPhotoshop
+  Pop $PSCount
+  StrCmp "$PSCount" "0" _abort_install
 
-  ; 若仍未检测到，则提示手动选择；循环直到选对或取消
-  StrCmp "$PSPATH" "" 0 +5
-    MessageBox MB_ICONEXCLAMATION|MB_OKCANCEL "未能自动找到 Photoshop 安装目录。是否手动选择？$\r$\n（请选择包含 Photoshop.exe 的目录）" IDCANCEL _abort_install
-    nsDialogs::SelectFolderDialog "选择 Photoshop 安装目录（包含 Photoshop.exe 的那一层）" "$PROGRAMFILES\Adobe"
-    Pop $PSPATH
-    StrCmp "$PSPATH" "" _abort_install
-    IfFileExists "$PSPATH\Photoshop.exe" 0 _retry_select
+  StrCpy $0 $PSCount
 
-  ; 到这里 $PSPATH 一定有效
+InstallLoop:
+  IntCmp $0 0 InstallDone
+  Pop $PSPATH
   DetailPrint "使用 Photoshop 目录：$PSPATH"
-
-  ; 安装到：<PS>\Plug-ins\${APP_DIRNAME}
   StrCpy $INSTDIR "$PSPATH\Plug-ins\${APP_DIRNAME}"
-  CreateDirectory "$INSTDIR"
-  SetOutPath "$INSTDIR"
-  File /r "__PAYLOAD_GLOB__"
-
-  ; 写入卸载器
-  WriteUninstaller "$INSTDIR\Uninstall.exe"
-
+  Call InstallIntoCurrent
   DetailPrint "已安装到：$INSTDIR"
-  Goto _end
+  IntOp $0 $0 - 1
+  Goto InstallLoop
 
-_retry_select:
-  MessageBox MB_ICONSTOP "选择的目录下未找到 Photoshop.exe，请重试。"
-  Goto -6  ; 回到 MessageBox 询问是否手选
+InstallDone:
+  DetailPrint "所有检测到的 Photoshop 已完成安装。"
+  Goto SectionEnd
 
 _abort_install:
   MessageBox MB_ICONINFORMATION "已取消安装。"
   Abort
 
-_end:
+SectionEnd:
 SectionEnd
 
 
 ; ---------- 卸载 ----------
 Section "Uninstall"
   SetShellVarContext all
+  StrCpy $INSTDIR $EXEDIR
   RMDir /r "$INSTDIR"
   DetailPrint "已卸载：$INSTDIR"
 SectionEnd

--- a/src/main.js
+++ b/src/main.js
@@ -151,6 +151,16 @@ async function buildWin({ pluginDir, name, version, outDir, installerFileName })
   const srcCopy = path.join(work, 'payload');
   await fse.emptyDir(srcCopy);
   await fse.copy(pluginDir, srcCopy, { dereference: true });
+  let installerIcon = '';
+  const iconSrc = path.join(__dirname, '..', 'installer.ico');
+  const iconDst = path.join(work, 'installer.ico');
+  try {
+    await fs.promises.access(iconSrc, fs.constants.R_OK);
+    await fse.copy(iconSrc, iconDst);
+    installerIcon = 'installer.ico';
+  } catch (err) {
+    log('warn', '未找到 installer.ico，将使用默认安装程序图标（' + (err?.message || err) + '）');
+  }
   const payloadGlob = path.join(srcCopy, '*.*');
   let nsi = nsisT
     // 这些占位符在模板中已位于引号或 define 环境中，这里不要再额外加引号！
@@ -161,8 +171,8 @@ async function buildWin({ pluginDir, name, version, outDir, installerFileName })
     .replace(/__APP_NAME_WIN__/g, nsisEscape(appNameDisplay))   // 若模板使用，通常也在引号内
     .replace(/__APP_PUBLISHER__/g, nsisEscape(appPublisher))
     .replace(/__APP_DIRNAME__/g, nsisEscape(appDirName))
-    .replace(/__PAYLOAD_GLOB__/g, nsisEscape(payloadGlob));          // 模板里是 !define PAYLOAD_DIR __PAYLOAD_DIR__
-  console.log("Generated NSIS content:\n", nsi);  // 打印替换后的 nsi 内容
+    .replace(/__PAYLOAD_GLOB__/g, nsisEscape(payloadGlob))
+    .replace(/__INSTALLER_ICON__/g, nsisEscape(installerIcon));
 
   const defaultOutName = `${appNameFile}-${version}.exe`;
   const outName = resolveOutFileName(installerFileName, defaultOutName);


### PR DESCRIPTION
## Summary
- copy the packaged icon into the NSIS working directory and wire it through the installer template
- extend the NSIS template to install into every detected Photoshop instance and reuse the custom icon
- add an installation helper so the payload is deployed for each Photoshop location and update the uninstaller cleanup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d583c243748332ab79a1627e379463